### PR TITLE
anova_tables2 function improvement

### DIFF
--- a/R/data_sheet.R
+++ b/R/data_sheet.R
@@ -5768,10 +5768,21 @@ DataSheet <- R6::R6Class(
         tibble::as_tibble(rownames = " ")
       
       # Add the total row if requested
+      # if (total) {
+      #   anova_mod <- anova_mod %>%
+      #     tibble::add_row(` ` = "Total", dplyr::summarise(., across(where(is.numeric), sum))) %>%
+      #     dplyr::mutate(`F value` = ifelse(` ` == "Total", "--", `F value`))  Replace NA with "--" for Total row
+      # }
+      # 
+      
+      # Add the total row if requested
       if (total) {
         anova_mod <- anova_mod %>%
           tibble::add_row(` ` = "Total", dplyr::summarise(., across(where(is.numeric), sum))) %>%
-          dplyr::mutate(`F value` = ifelse(` ` == "Total", "--", `F value`)) # Replace NA with "--" for Total row
+          dplyr::mutate(
+            `F value` = ifelse(` ` == "Total", "--", as.character(`F value`)),
+            `Mean Sq` = ifelse(` ` == "Total", "--", formatC(`Mean Sq`, format = "f", digits = 3))
+          )
       }
       
       # Handle significance levels

--- a/databook.Rproj
+++ b/databook.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: f298021f-49c1-4c12-8c20-e5b7c3210917
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Fixes https://github.com/IDEMSInternational/R-Instat/issues/9503
I replaced the **Mean Sq - Total** cell with "--" instead of showing the sum of Mean Squares (which it originally produced) or the SST/DF value suggested by @rdstern. From most of the ANOVA tables I’ve seen, that cell is typically left empty.  

Below is the new layout I propose.

![image](https://github.com/user-attachments/assets/66bc27b7-602e-4519-aaaa-da52ee4de6fd)

@rdstern  and @lilyclements , could you please review?