### PR TITLE
Insert rows gives errors when rows are not the positive integers

### DIFF
--- a/R/data_sheet.R
+++ b/R/data_sheet.R
@@ -1859,6 +1859,9 @@ DataSheet <- R6::R6Class(
     insert_row_in_data = function(start_row, row_data = c(), number_rows = 1, before = FALSE) {
       curr_data <- self$get_data_frame(use_current_filter = FALSE)
       self$save_state_to_undo_history()
+      if (tibble::has_rownames(curr_data)) {
+        stop ("Sorry , there are some operations that are not allowed when  data includes rownames. The details are explained in the help.")
+      }
       curr_row_names <- rownames(curr_data)
       if (!start_row %in% curr_row_names) {
         stop(paste(start_row, " not found in rows"))

--- a/databook.Rproj
+++ b/databook.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 4eda9100-3ed3-45d5-a75e-c3e95ada7e98
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION

fixes https://github.com/IDEMSInternational/R-Instat/issues/8536
@rdstern
![Screenshot 2025-05-01 153951](https://github.com/user-attachments/assets/d5f2469a-d7f6-4d02-b54a-138ac073a0bf)

@lilyclements Kindly check 
Error message update
Refined the error message. "Sorry , there are some operations that are not allowed when  data includes row names. The details are explained in the help."


