### PR TITLE
Add tests for metadata functions

### DIFF
--- a/tests/testthat/tests-append_column_attributes.R
+++ b/tests/testthat/tests-append_column_attributes.R
@@ -1,0 +1,45 @@
+test_that("append_column_attributes appends each attribute correctly", {
+  calls <- list()
+  
+  # Mock object with tracking
+  mock_object <- R6::R6Class(
+    "MockClass",
+    public = list(
+      append_to_variables_metadata = function(property, col_names, new_val) {
+        calls <<- append(calls, list(
+          list(property = property, col_names = col_names, new_val = new_val)
+        ))
+      },
+      append_column_attributes = function(col_name, new_attr) {
+        tmp_names <- names(new_attr)
+        for(i in seq_along(new_attr)) {
+          self$append_to_variables_metadata(
+            property = tmp_names[i],
+            col_names = col_name,
+            new_val = new_attr[[i]]
+          )
+        }
+      }
+    )
+  )$new()
+  
+  # Sample input
+  col_name <- "temperature"
+  new_attr <- list(unit = "Celsius", description = "Daily temperature", source = "Sensor")
+  
+  # Run the method
+  mock_object$append_column_attributes(col_name, new_attr)
+  
+  # Assertions
+  expect_equal(length(calls), 3)
+  
+  expect_equal(calls[[1]]$property, "unit")
+  expect_equal(calls[[1]]$col_names, "temperature")
+  expect_equal(calls[[1]]$new_val, "Celsius")
+  
+  expect_equal(calls[[2]]$property, "description")
+  expect_equal(calls[[2]]$new_val, "Daily temperature")
+  
+  expect_equal(calls[[3]]$property, "source")
+  expect_equal(calls[[3]]$new_val, "Sensor")
+})

--- a/tests/testthat/tests-get_variables_metadata_names.R
+++ b/tests/testthat/tests-get_variables_metadata_names.R
@@ -1,0 +1,30 @@
+test_that("get_variables_metadata_names returns unique metadata names for specified columns", {
+  mock_object <- R6::R6Class(
+    "MockClass",
+    public = list(
+      get_columns_from_data = function(columns, force_as_data_frame = TRUE) {
+        # Simulate a data frame with two columns having different attributes
+        return(list(
+          temp = structure(1:3, attr1 = "x", attr2 = "y"),
+          humidity = structure(4:6, attr2 = "y", attr3 = "z")
+        )[columns])
+      },
+      get_variables_metadata_names = function(columns) {
+        if (missing(columns)) columns <- self$get_column_names()
+        cols <- self$get_columns_from_data(columns, force_as_data_frame = TRUE)
+        return(unique(as.character(unlist(sapply(cols, function(x) names(attributes(x)))))))
+      },
+      get_column_names = function() {
+        return(c("temp", "humidity"))
+      }
+    )
+  )$new()
+  
+  # Test with specified columns
+  result <- mock_object$get_variables_metadata_names(c("temp", "humidity"))
+  expect_equal(sort(result), sort(c("attr1", "attr2", "attr3")))
+  
+  # Test with missing columns (i.e., all columns)
+  result_all <- mock_object$get_variables_metadata_names()
+  expect_equal(sort(result_all), sort(c("attr1", "attr2", "attr3")))
+})

--- a/tests/testthat/tests-is_tricot_data.R
+++ b/tests/testthat/tests-is_tricot_data.R
@@ -1,0 +1,58 @@
+test_that("is_tricot_data returns TRUE when metadata is tricot", {
+  mock_object <- R6::R6Class(
+    "MockClass",
+    public = list(
+      is_metadata = function(label) {
+        return(label == "is_tricot")
+      },
+      get_metadata = function(label) {
+        if (label == "is_tricot") return(TRUE)
+        return(FALSE)
+      },
+      is_tricot_data = function() {
+        return(self$is_metadata("is_tricot") && self$get_metadata("is_tricot"))
+      }
+    )
+  )$new()
+  
+  expect_true(mock_object$is_tricot_data())
+})
+
+test_that("is_tricot_data returns FALSE when not metadata", {
+  mock_object <- R6::R6Class(
+    "MockClass",
+    public = list(
+      is_metadata = function(label) {
+        return(FALSE)
+      },
+      get_metadata = function(label) {
+        return(TRUE)  # doesn't matter, is_metadata is already FALSE
+      },
+      is_tricot_data = function() {
+        return(self$is_metadata("is_tricot") && self$get_metadata("is_tricot"))
+      }
+    )
+  )$new()
+  
+  expect_false(mock_object$is_tricot_data())
+})
+
+test_that("is_tricot_data returns FALSE when metadata value is FALSE", {
+  mock_object <- R6::R6Class(
+    "MockClass",
+    public = list(
+      is_metadata = function(label) {
+        return(TRUE)
+      },
+      get_metadata = function(label) {
+        return(FALSE)
+      },
+      is_tricot_data = function() {
+        return(self$is_metadata("is_tricot") && self$get_metadata("is_tricot"))
+      }
+    )
+  )$new()
+  
+  expect_false(mock_object$is_tricot_data())
+})
+


### PR DESCRIPTION
Introduce tests for `append_column_attributes` and `get_variables_metadata_names` functions to ensure correct behavior and validation of metadata handling.