### PR TITLE
Fix in climdex code

### DIFF
--- a/R/data_book.R
+++ b/R/data_book.R
@@ -2895,6 +2895,13 @@ DataBook <- R6::R6Class("DataBook",
                               links_cols <- c()
                               if (missing(station)) stop("station is required for freq = 'station'.")
                               if ("year" %in% names(climdex_output)) climdex_output$year <- NULL
+                              
+                              # adding fix to remove duplicate rows for the station (because of year being set as station to allow for station-specific climdex summaries)
+                              remove_all_na_rows <- function(climdex_output, station) {
+                                climdex_output %>%
+                                  dplyr::filter(dplyr::if_any(-dplyr::all_of(station), ~ !is.na(.)))
+                              }
+                              climdex_output <- remove_all_na_rows(climdex_output, station)
                             }
                             
                             # All


### PR DESCRIPTION
As explained in [9807](https://github.com/IDEMSInternational/R-Instat/pull/9807)

When running for station, we need to set `year` anyway, so we set `year = "<station column>"` to bypass this.
But then an error on keys would come if we set `year = "<station column>"`, because now station isn't a unique row -- we have station repeated a few times but with the year absent.
We just therefore need to get rid of those NA years this R code resolves.