### PR TITLE
Add tests for DataSheet methods

### DIFF
--- a/tests/testthat/tests-append_to_changes.R
+++ b/tests/testthat/tests-append_to_changes.R
@@ -1,0 +1,60 @@
+# Define symbolic constants
+Added_metadata <- "Added_metadata"
+is_hidden_label <- "is_hidden"
+
+# Minimal class definition
+DataSheet <- R6::R6Class("DataSheet",
+                     private = list(
+                       data = data.frame(a = 1:3),
+                       changes = list()
+                     ),
+                     public = list(
+                       metadata_changed = FALSE,
+                       data_changed = FALSE,
+                       
+                       append_to_changes = function(change) {
+                         private$changes <- append(private$changes, list(change))
+                       },
+                       
+                       get_changes = function() {
+                         private$changes
+                       },
+                       
+                       append_to_metadata = function(property, new_value = "") {
+                         if (missing(property)) stop("property must be specified.")
+                         if (!is.character(property)) stop("property must be of type: character")
+                         
+                         attr(private$data, property) <- new_value
+                         self$append_to_changes(list(Added_metadata, property, new_value))
+                         self$metadata_changed <- TRUE
+                         if (property == is_hidden_label) self$data_changed <- TRUE
+                       },
+                       
+                       get_data = function() {
+                         private$data
+                       }
+                     )
+)
+
+# Unit test
+test_that("append_to_metadata adds metadata correctly", {
+  ds <- DataSheet$new()
+  
+  ds$append_to_metadata("source", "MOH Kenya")
+  
+  expect_equal(attr(ds$get_data(), "source"), "MOH Kenya")
+  
+  expected_change <- list(Added_metadata, "source", "MOH Kenya")
+  expect_equal(ds$get_changes()[[1]], expected_change)
+  
+  expect_true(ds$metadata_changed)
+})
+
+test_that("append_to_metadata sets data_changed if is_hidden_label is used", {
+  ds <- DataSheet$new()
+  
+  ds$append_to_metadata("is_hidden", TRUE)
+  
+  expect_equal(attr(ds$get_data(), "is_hidden"), TRUE)
+  expect_true(ds$data_changed)
+})

--- a/tests/testthat/tests-get_changes.R
+++ b/tests/testthat/tests-get_changes.R
@@ -1,0 +1,28 @@
+DataSheet <- R6::R6Class("DataSheet",
+                     private = list(
+                       changes = list()
+                     ),
+                     public = list(
+                       append_to_changes = function(change) {
+                         private$changes <- append(private$changes, list(change))
+                       },
+                       get_changes = function() {
+                         return(private$changes)
+                       }
+                     )
+)
+
+test_that("get_changes returns correct list of changes", {
+  ds <- DataSheet$new()
+  ds$append_to_changes(list("Set_property", "comments"))
+  ds$append_to_changes(list("Delete_column", "age"))
+  
+  result <- ds$get_changes()
+  
+  expected <- list(
+    list("Set_property", "comments"),
+    list("Delete_column", "age")
+  )
+  
+  expect_equal(result, expected)
+})


### PR DESCRIPTION
Introduce unit tests for the `append_to_metadata` and `get_changes` methods in the DataSheet class to ensure correct functionality and state management.