### PR TITLE
Added unit tests for summary functions

### DIFF
--- a/tests/testthat/tests-get_summary_calculation_names.R
+++ b/tests/testthat/tests-get_summary_calculation_names.R
@@ -1,0 +1,47 @@
+test_that("get_summary_calculation_names works without filters", {
+  summaries <- c("summary_mean", "summary_sum")
+  columns <- c("col1", "col2")
+  filters <- list(list(name = "nofilter", parameters = list(is_no_filter = TRUE)))
+  
+  result <- get_summary_calculation_names(NULL, summaries, columns, filters)
+  
+  # Expected order follows expand.grid() default behavior
+  expected <- c("mean.col1", "sum.col1", "mean.col2", "sum.col2")
+  expect_equal(result, expected)
+})
+
+test_that("get_summary_calculation_names works with a single filter", {
+  summaries <- c("summary_mean")
+  columns <- c("col1")
+  filters <- list(list(name = "filtA", parameters = list(is_no_filter = FALSE)))
+  
+  result <- get_summary_calculation_names(NULL, summaries, columns, filters)
+  
+  expected <- c("mean.col1_filtA")
+  expect_equal(result, expected)
+})
+
+test_that("get_summary_calculation_names works with multiple filters", {
+  summaries <- c("summary_mean")
+  columns <- c("col1")
+  filters <- list(
+    list(name = "filtA", parameters = list(is_no_filter = FALSE)),
+    list(name = "filtB", parameters = list(is_no_filter = FALSE))
+  )
+  
+  result <- get_summary_calculation_names(NULL, summaries, columns, filters)
+  
+  expected <- c("mean.col1_filtA.filtB")
+  expect_equal(result, expected)
+})
+
+test_that("get_summary_calculation_names returns valid names", {
+  summaries <- c("summary mean")
+  columns <- c("col 1")
+  filters <- list(list(name = "filt with space", parameters = list(is_no_filter = FALSE)))
+  
+  result <- get_summary_calculation_names(NULL, summaries, columns, filters)
+  
+  # make.names ensures valid R variable names
+  expect_true(all(make.names(result) == result))
+})

--- a/tests/testthat/tests-link.R
+++ b/tests/testthat/tests-link.R
@@ -1,5 +1,3 @@
-library(testthat)
-
 test_that("link class methods behave as expected", {
   # Create a link object
   link_obj <- link$new(

--- a/tests/testthat/tests-missing_values_check.R
+++ b/tests/testthat/tests-missing_values_check.R
@@ -1,0 +1,9 @@
+test_that("missing_values_check always returns FALSE", {
+  # Different types of inputs
+  expect_false(missing_values_check(c(1, 2, 3)))
+  expect_false(missing_values_check(c(NA, 2, 3)))
+  expect_false(missing_values_check(NULL))
+  expect_false(missing_values_check(character()))
+  expect_false(missing_values_check(logical()))
+  expect_false(missing_values_check(c(TRUE, FALSE, NA)))
+})

--- a/tests/testthat/tests-summary_mode.R
+++ b/tests/testthat/tests-summary_mode.R
@@ -1,0 +1,28 @@
+test_that("summary_mode works with numeric vectors", {
+  x <- c(1, 2, 2, 3, 3, 3, 4)
+  expect_equal(summary_mode(x), 3)
+})
+
+test_that("summary_mode works with character vectors", {
+  x <- c("apple", "banana", "apple", "cherry")
+  expect_equal(summary_mode(x), "apple")
+})
+
+test_that("summary_mode works with factors", {
+  x <- factor(c("red", "blue", "red", "green"))
+  expect_equal(summary_mode(x), "red") # coerced to character
+})
+
+test_that("summary_mode returns first mode when tie occurs", {
+  x <- c(1, 1, 2, 2)
+  expect_equal(summary_mode(x), 1) # first mode wins
+})
+
+test_that("summary_mode returns NA for NULL input", {
+  expect_true(is.na(summary_mode(NULL)))
+})
+
+test_that("summary_mode ignores NA values when possible", {
+  x <- c(1, 2, 2, NA, NA, 2)
+  expect_equal(summary_mode(x), 2)
+})


### PR DESCRIPTION
Introduced unit tests for `get_summary_calculation_names` and `summary_mode` functions, ensuring their correctness across various input scenarios. Implement a test for `missing_values_check` 